### PR TITLE
Install local code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,9 @@ Clone the repo:
 ```
 git clone git@github.com:kelsdoerksen/airPy.git
 ```
-Navigate to the airPy folder and install the package using `pip`.
+Navigate to the airPy folder and install the package and dependencies using `pip`.
 ```
-pip install airpy
-```
-Install package dependencies using
-```
-pip install -r requirements.txt  
+pip install . -r requirements.txt
 ```
 
 


### PR DESCRIPTION
`pip install airpy` will install the [airpy project from PyPI](https://pypi.org/project/airpy/) which looks unrelated. This updates the docs to install from the local project code.