### PR TITLE
Fix incompatible dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ markdown-it-py==3.0.0
 matplotlib==3.6.2
 matplotlib-inline==0.1.6
 mdurl==0.1.2
-mkl-fft==1.3.1
+mkl-fft==1.3.6
 mkl-random==1.2.2
 mkl-service==2.4.0
 mock==4.0.3
@@ -58,7 +58,7 @@ more-itertools==9.1.0
 multidict==6.0.4
 munkres==1.1.4
 numexpr==2.8.4
-numpy==1.22.3
+numpy==1.24.3
 packaging==22.0
 pandas==1.5.2
 parso==0.8.3


### PR DESCRIPTION
Without this change, I got the following error when trying to install the project:

```
ERROR: Cannot install -r requirements.txt (line 101), -r requirements.txt (line 102), -r requirements.txt (line 106), -r requirements.txt (line 120), -r requirements.txt (line 17), -r requirements.txt (line 24), -r requirements.txt (line 3), -r requirements.txt (line 4), -r requirements.txt (line 44), -r requirements.txt (line 47), -r requirements.txt (line 58), -r requirements.txt (line 65), -r requirements.txt (line 68) and numpy==1.22.3 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==1.22.3
    mkl-fft 1.3.1 depends on numpy<1.23.0 and >=1.22.3
    bottleneck 1.3.5 depends on numpy
    contourpy 1.0.5 depends on numpy>=1.16
    h5py 3.7.0 depends on numpy>=1.14.5
    imageio 2.19.3 depends on numpy
    matplotlib 3.6.2 depends on numpy>=1.19
    numexpr 2.8.4 depends on numpy>=1.13.3
    pandas 1.5.2 depends on numpy>=1.20.3; python_version < "3.10"
    scikit-learn 1.2.0 depends on numpy>=1.17.3
    scipy 1.9.3 depends on numpy<1.26.0 and >=1.18.5
    tables 3.7.0 depends on numpy>=1.19.0
    xarray 2022.11.0 depends on numpy>=1.20
    mkl-random 1.2.2 depends on numpy<1.25.0 and >=1.24.3

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```