### PR TITLE
Avoid using hard-coded path for test config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # PyCharm IDE
 .idea/
+
+/airpy_save_dir

--- a/airpy/tests/test_config.json
+++ b/airpy/tests/test_config.json
@@ -28,6 +28,6 @@
     "query_month": "jan",
     "analysis_type": "collection",
     "buffer_size": "55500",
-    "save_dir": "/Users/kelseydoerksen/Desktop",
+    "save_dir": "./airpy_save_dir",
     "add_time": false
 }


### PR DESCRIPTION
Tests were failing before because the directory doesn't exist.